### PR TITLE
Add nilchecks for strings in SANEOptionDescriptor

### DIFF
--- a/SaneKit/Sane.swift
+++ b/SaneKit/Sane.swift
@@ -277,9 +277,9 @@ public struct SANEOptionDescriptor {
     public let constraint: SANEConstraint
 
     init(from saneDescriptor: libsane.SANE_Option_Descriptor) throws {
-        self.name = String(cString: saneDescriptor.name)
-        self.title = String(cString: saneDescriptor.title)
-        self.desc = String(cString: saneDescriptor.desc)
+        self.name = saneDescriptor.name != nil ? String(cString: saneDescriptor.name) : ""
+        self.title = saneDescriptor.title != nil ? String(cString: saneDescriptor.title) : ""
+        self.desc = saneDescriptor.desc != nil ? String(cString: saneDescriptor.desc) : ""
         self.type = try SANEValueType(from: saneDescriptor.type)
         self.unit = try SANEUnit(from: saneDescriptor.unit)
         self.size = Int(saneDescriptor.size)


### PR DESCRIPTION
Thanks for this project! I stumbled upon it when trying to get my old Epson Stylus SX218 to scan to a Macbook running macOS 13, and SANE turned out to be an excellent option.

When trying to build it, I ran into an error; for some reason the `saneDescriptor.name` attribute was `nil` for my specific scanner. I don't claim to really understand SANE at all, but after applying the fix in the commit (i.e., setting nil-values to the empty string), I do not see any notable missing strings, so I'm unsure what the specific option is that is triggering this..

In addition to no experience with SANE, this is also the first Swift code I've edited, so if there's a better way to fix this, by all means (I tried using the [Nil Coalescing Operator](https://stackoverflow.com/a/32170457) but couldn't get that to work with the `String` constructor..)